### PR TITLE
Inject matplotlib fix into code cells

### DIFF
--- a/src/sphinx_thebe/_static/sphinx-thebe-lite.js
+++ b/src/sphinx_thebe/_static/sphinx-thebe-lite.js
@@ -202,7 +202,7 @@ var modifyDOMForThebe = () => {
     if (codeCellText) {
       codeCellText.setAttribute("data-language", dataLanguage);
       codeCellText.setAttribute("data-executable", "true");
-      // Modify each code cell, as execution by a user may not be linear
+      // Modify each code cell, as execution by a user may not be linear. Patches: https://github.com/TeachBooks/TeachBooks-Sphinx-Thebe/issues/8
       const extraLines = `# Start of injected lines\nimport matplotlib\nif not hasattr(matplotlib.RcParams, "_get"):\n    matplotlib.RcParams._get = dict.get\n# End of injected lines\n\n`;
       codeCellText.textContent = extraLines + codeCellText.textContent;
       console.log("Injected matplotlib fix into code cell", index);

--- a/src/sphinx_thebe/_static/sphinx-thebe-lite.js
+++ b/src/sphinx_thebe/_static/sphinx-thebe-lite.js
@@ -202,6 +202,10 @@ var modifyDOMForThebe = () => {
     if (codeCellText) {
       codeCellText.setAttribute("data-language", dataLanguage);
       codeCellText.setAttribute("data-executable", "true");
+      // Modify each code cell, as execution by a user may not be linear
+      const extraLines = `# Start of injected lines\nimport matplotlib\nif not hasattr(matplotlib.RcParams, "_get"):\n    matplotlib.RcParams._get = dict.get\n# End of injected lines\n\n`;
+      codeCellText.textContent = extraLines + codeCellText.textContent;
+      console.log("Injected matplotlib fix into code cell", index);
     }
 
     // Remove sphinx-copybutton blocks, which are common in Sphinx


### PR DESCRIPTION
Prepends code to each executable code cell to patch matplotlib's RcParams._get method if missing. This ensures compatibility and prevents errors during code execution in Thebe environments.

Solves https://github.com/TeachBooks/TeachBooks-Sphinx-Thebe/issues/8

Example of working code: https://teachbooks.io/manual/matplotlib_inline_fix/features/widgets.html

Tests can be done with

`git+https://github.com/TeachBooks/TeachBooks-Favourites@fix-matplotlib` (if Teachbooks-Favourites is used)

or with

`git+https://github.com/TeachBooks/Sphinx-Thebe@fix-issue-8`